### PR TITLE
Enhance project_root detecting. Make jdtls config.settings configuabl…

### DIFF
--- a/autoload/class_generator.vim
+++ b/autoload/class_generator.vim
@@ -79,7 +79,7 @@ endfunction
 
 function! s:FetchAvailablePackages(command, completed, isRelative)
   let result = []
-  let currentPath = split(expand('%:p:h'), g:FILE_SEP)
+  let currentPath = split(expand('%:p:h'), g:utils#FILE_SEP)
   if a:isRelative == 0
     let currentPackage = split(s:GetPackage(), '\.')
     echom currentPath
@@ -97,10 +97,10 @@ function! s:FetchAvailablePackages(command, completed, isRelative)
       endif
     endif
   endif
-  let command = substitute(a:command, '\.', g:FILE_SEP, 'g')
-  let cutLength = len(join(currentPath, g:FILE_SEP)) + 2
-  for path in glob(g:FILE_SEP. join(currentPath, g:FILE_SEP). g:FILE_SEP. '**'. g:FILE_SEP. command. '*'. g:FILE_SEP, 1, 1)
-    let p = substitute(path[cutLength:], g:FILE_SEP, '.', 'g')
+  let command = substitute(a:command, '\.', g:utils#FILE_SEP, 'g')
+  let cutLength = len(join(currentPath, g:utils#FILE_SEP)) + 2
+  for path in glob(g:utils#FILE_SEP. join(currentPath, g:utils#FILE_SEP). g:utils#FILE_SEP. '**'. g:utils#FILE_SEP. command. '*'. g:utils#FILE_SEP, 1, 1)
+    let p = substitute(path[cutLength:], g:utils#FILE_SEP, '.', 'g')
     if a:isRelative == 0
       let p = '/'. p
     endif
@@ -119,7 +119,7 @@ function! s:FetchKeywords(command, completed, isRelative)
   let completed = completed. join(tokens[:-2], ' ')
   let result = []
   for kw in keywords
-    if a:command =~ '\<'. kw. '\>' 
+    if a:command =~ '\<'. kw. '\>'
           \ || kw !~ '\<'. tokens[-1]. '*'
       continue
     endif
@@ -130,11 +130,11 @@ endfunction
 
 function! s:FetchAvailableSubDirectories(command, completed)
   let result = []
-  let currentPath = split(expand('%:p:h'), g:FILE_SEP)
+  let currentPath = split(expand('%:p:h'), g:utils#FILE_SEP)
   let currentPath = currentPath[:index(currentPath, 'src')]
-  let prePath = g:FILE_SEP. join(currentPath, g:FILE_SEP). g:FILE_SEP
+  let prePath = g:utils#FILE_SEP. join(currentPath, g:utils#FILE_SEP). g:utils#FILE_SEP
   let cutLength = len(prePath)
-  for path in glob(prePath. a:command. '*'. g:FILE_SEP, 0, 1)
+  for path in glob(prePath. a:command. '*'. g:utils#FILE_SEP, 0, 1)
     call add(result, a:completed. '['. path[cutLength:-2]. ']')
   endfor
   return result
@@ -166,7 +166,7 @@ function! class_generator#CreateInFile()
   let message .= "\nenter template name [default]: "
   let userinput = input(message, '', 'customlist,class_generator#TemplatesCompletion')
 
-  let currentPath = split(expand('%:p:h'), g:FILE_SEP)
+  let currentPath = split(expand('%:p:h'), g:utils#FILE_SEP)
   call filter(currentPath, 'empty(v:val) == 0')
   if has('win32') && currentPath[0][-1:] ==':'
     let currentPath = currentPath[1:]
@@ -174,7 +174,7 @@ function! class_generator#CreateInFile()
 
   let data = {}
   let data['path'] = ''
-  let data['current_path'] = g:FILE_SEP. join(currentPath, g:FILE_SEP)
+  let data['current_path'] = g:utils#FILE_SEP. join(currentPath, g:utils#FILE_SEP)
   let data['class'] = expand('%:t:r')
   let data['package'] = s:DeterminePackage(currentPath)
   if !empty(userinput)
@@ -222,7 +222,7 @@ function! class_generator#CreateClass()
   endif
 
   let currentPackage = split(s:GetPackage(), '\.')
-  let currentPath = split(expand('%:p:h'), g:FILE_SEP)
+  let currentPath = split(expand('%:p:h'), g:utils#FILE_SEP)
   call filter(currentPath, 'empty(v:val) == 0')
   if has('win32') && currentPath[0][-1:] ==':'
     let currentPath = currentPath[1:]
@@ -234,18 +234,18 @@ function! class_generator#CreateClass()
     echoerr "Error: could not parse input line"
     return
   endif
-  let data['current_path'] = g:FILE_SEP. join(currentPath, g:FILE_SEP). g:FILE_SEP
+  let data['current_path'] = g:utils#FILE_SEP. join(currentPath, g:utils#FILE_SEP). g:utils#FILE_SEP
   call s:CreateClass(data)
 endfunction
 
 function! s:CreateClass(data)
   let path = a:data['current_path']
-        \ . g:FILE_SEP
+        \ . g:utils#FILE_SEP
         \ . a:data['path']
   if filewritable(path) != 2
     call mkdir(path, 'p')
   endif
-  let fileName = fnamemodify(path. g:FILE_SEP. a:data['class'], ":p")
+  let fileName = fnamemodify(path. g:utils#FILE_SEP. a:data['class'], ":p")
   let bufname = bufname('')
   if getbufvar(bufname, "&mod") == 1 && getbufvar(bufname, "&hidden") == 0
     execute ':vs'
@@ -254,8 +254,8 @@ function! s:CreateClass(data)
   let fileSize = getfsize(fileName. '.java')
   if (fileSize <= 0 && fileSize > -2) || (line('$') == 1 && getline(1) == '')
     let options = {
-          \ 'name' : a:data['class'], 
-          \ 'package' : a:data['package'] 
+          \ 'name' : a:data['class'],
+          \ 'package' : a:data['package']
           \ }
     if has_key(a:data, 'fields')
       let options['fields'] = a:data['fields']
@@ -397,7 +397,7 @@ function! s:ParseFields(fields)
       let fieldMatch = matchlist(field, '^\s*\(\%('. g:RE_TYPE_MODS. '\s\+\)\+\)\=\('. g:RE_TYPE. '\)\s\+\('. g:RE_IDENTIFIER. '\).*$')
       if !empty(fieldMatch)
         let fieldMap = {}
-        let fieldMap['mod'] = empty(fieldMatch[1]) ? 
+        let fieldMap['mod'] = empty(fieldMatch[1]) ?
               \ 'private' : utils#trim(fieldMatch[1])
         let fieldMap['type'] = fieldMatch[2]
         let fieldMap['name'] = fieldMatch[3]
@@ -413,9 +413,9 @@ endfunction
 function! s:BuildPathData(path, subdir, currentPath, currentPackage)
   if !empty(a:subdir)
     let idx = index(a:currentPath, 'src')
-    let newPath = repeat('..'. g:FILE_SEP, idx)
-    let newPath .= a:subdir. g:FILE_SEP. 'java'. g:FILE_SEP
-    let newPath .= join(a:currentPackage, g:FILE_SEP). g:FILE_SEP
+    let newPath = repeat('..'. g:utils#FILE_SEP, idx)
+    let newPath .= a:subdir. g:utils#FILE_SEP. 'java'. g:utils#FILE_SEP
+    let newPath .= join(a:currentPackage, g:utils#FILE_SEP). g:utils#FILE_SEP
   else
     let newPath = ''
   endif
@@ -434,22 +434,22 @@ function! s:BuildPathData(path, subdir, currentPath, currentPackage)
     let currentPath = a:currentPath[:sameSubpackageIdx]
     let idx = index(currentPath, path[0])
     if idx < 0
-      let newPath .= repeat('..'. g:FILE_SEP, len(currentPath))
-      let newPath .= join(path[:-2], g:FILE_SEP)
+      let newPath .= repeat('..'. g:utils#FILE_SEP, len(currentPath))
+      let newPath .= join(path[:-2], g:utils#FILE_SEP)
       let newPackage = path[:-2]
     else
-      let newPath .= idx > 0 ? 
-            \ repeat('..'. g:FILE_SEP, 
-            \ len(currentPath[:idx-1])) 
-            \ : 
+      let newPath .= idx > 0 ?
+            \ repeat('..'. g:utils#FILE_SEP,
+            \ len(currentPath[:idx-1]))
+            \ :
             \ ''
-      let newPath .= join(path[1:-2], g:FILE_SEP)
+      let newPath .= join(path[1:-2], g:utils#FILE_SEP)
       let newPackage = path[1:-2]
       call extend(newPackage, reverse(currentPath)[:-idx-1], 0)
     endif
     return {
-          \ 'path' : newPath, 
-          \ 'class' : path[-1], 
+          \ 'path' : newPath,
+          \ 'class' : path[-1],
           \ 'package' : join(newPackage, '.')
           \ }
   else
@@ -460,8 +460,8 @@ endfunction
 function! s:RelativePath(path, newPath, currentPath, currentPackage)
   let newPackage = join(a:currentPackage + a:path[:-2], '.')
   return {
-        \ 'path' : a:newPath. join(a:path[:-2], g:FILE_SEP), 
-        \ 'class' : a:path[-1], 
+        \ 'path' : a:newPath. join(a:path[:-2], g:utils#FILE_SEP),
+        \ 'class' : a:path[-1],
         \ 'package' : newPackage
         \ }
 endfunction

--- a/autoload/project_root.vim
+++ b/autoload/project_root.vim
@@ -1,17 +1,5 @@
-function! s:is_windows() abort
-    return has("win32") || has("win64") || has("win16") || has("dos32") || has("dos16")
-endfunction
-
-if s:is_windows()
-    let g:PATH_SEP    = ';'
-    let g:FILE_SEP    = '\'
-else
-    let g:PATH_SEP    = ':'
-    let g:FILE_SEP    = '/'
-endif
-
 function! project_root#get_basedir(extra)
-    let dir = get(g:, 'jc_basedir', expand('~'. g:FILE_SEP. '.local'. g:FILE_SEP. 'share')). g:FILE_SEP. 'jc.nvim'. g:FILE_SEP. a:extra. g:FILE_SEP
+    let dir = get(g:, 'jc_basedir', expand('~'. g:utils#FILE_SEP. '.local'. g:utils#FILE_SEP. 'share')). g:utils#FILE_SEP. 'jc.nvim'. g:utils#FILE_SEP. a:extra. g:utils#FILE_SEP
     call mkdir(dir, "p")
     return dir
 endfunction
@@ -28,36 +16,49 @@ endfunction
 function! project_root#find()
     if !get(g:, 'JavaComplete_MavenRepositoryDisabled', 0)
         if !exists('g:JavaComplete_PomPath')
-            let g:JavaComplete_PomPath = project_root#find_file('pom.xml')
-            if g:JavaComplete_PomPath != ""
-                return fnamemodify(g:JavaComplete_PomPath, ':p')
+            if filereadable(getcwd() . g:utils#FILE_SEP . "pom.xml")
+                let g:JavaComplete_PomPath = getcwd() . g:utils#FILE_SEP . "pom.xml"
+            else
+                let g:JavaComplete_PomPath = project_root#find_file('pom.xml')
             endif
+        endif
+        if g:JavaComplete_PomPath != ""
+            let g:JavaComplete_PomPath = fnamemodify(g:JavaComplete_PomPath, ':p')
+            return g:JavaComplete_PomPath
+        else
+            unlet g:JavaComplete_PomPath
         endif
     endif
 
     if !get(g:, 'JavaComplete_GradleRepositoryDisabled', 0)
         if !exists('g:JavaComplete_GradlePath')
-            if filereadable(getcwd(). g:FILE_SEP. "build.gradle")
-                let g:JavaComplete_GradlePath = getcwd(). g:FILE_SEP. "build.gradle"
+            if filereadable(getcwd() . g:utils#FILE_SEP . "build.gradle")
+                let g:JavaComplete_GradlePath = getcwd() . g:utils#FILE_SEP . "build.gradle"
             else
-                let g:JavaComplete_GradlePath = project_root#find_file('build.gradle', '**3')
+                let g:JavaComplete_GradlePath = project_root#find_file('build.gradle')
             endif
-            if g:JavaComplete_GradlePath != ""
-                return fnamemodify(g:JavaComplete_GradlePath, ':p')
-            endif
+        endif
+        if g:JavaComplete_GradlePath != ""
+            let g:JavaComplete_GradlePath = fnamemodify(g:JavaComplete_GradlePath, ':p')
+            return g:JavaComplete_GradlePath
+        else
+            unlet g:JavaComplete_GradlePath
         endif
     endif
 
     if !get(g:, 'JavaComplete_AntRepositoryDisabled', 0)
         if !exists('g:JavaComplete_AntPath')
-            if filereadable(getcwd(). g:FILE_SEP. "build.xml")
-                let g:JavaComplete_AntPath = getcwd(). g:FILE_SEP. "build.xml"
+            if filereadable(getcwd() . g:utils#FILE_SEP . "build.xml")
+                let g:JavaComplete_AntPath = getcwd() . g:utils#FILE_SEP . "build.xml"
             else
-                let g:JavaComplete_AntPath = project_root#find_file('build.xml', '**3')
+                let g:JavaComplete_AntPath = project_root#find_file('build.xml')
             endif
-            if g:JavaComplete_AntPath != ""
-                return fnamemodify(g:JavaComplete_AntPath, ':p')
-            endif
+        endif
+        if g:JavaComplete_AntPath != ""
+            let g:JavaComplete_AntPath = fnamemodify(g:JavaComplete_AntPath, ':p')
+            return g:JavaComplete_AntPath
+        else
+            unlet g:JavaComplete_AntPath
         endif
     endif
 
@@ -69,7 +70,7 @@ function! project_root#find_file(what, ...) abort
     let old_suffixesadd = &suffixesadd
     try
         let &suffixesadd = ''
-        return findfile(a:what, escape(expand('.'), '*[]?{}, ') . direction)
+        return findfile(a:what, escape(expand('%:p'), '*[]?{}, ') . direction)
     finally
         let &suffixesadd = old_suffixesadd
     endtry

--- a/autoload/project_root.vim
+++ b/autoload/project_root.vim
@@ -1,3 +1,18 @@
+let g:project_root#patterns = get(g:, 'project_root#patterns',  ['mvnw', 'gradlew', 'pom.xml', 'build.gradle', 'build.xml'])
+
+function! s:find_root_pattern(p)
+  let root_files = findfile(a:p, escape(expand('%:p'), '*[]?{}, ').';', -1)->map('fnamemodify(v:val, ":p")')
+  let shortest = 999999
+  let root_file = ''
+  for f in root_files
+    if len(f) < shortest
+      let root_file = f
+      let shortest = len(f)
+    endif
+  endfor
+  return root_file
+endfunction
+
 function! project_root#get_basedir(extra)
     let dir = get(g:, 'jc_basedir', expand('~'. g:utils#FILE_SEP. '.local'. g:utils#FILE_SEP. 'share')). g:utils#FILE_SEP. 'jc.nvim'. g:utils#FILE_SEP. a:extra. g:utils#FILE_SEP
     call mkdir(dir, "p")
@@ -15,52 +30,35 @@ endfunction
 
 function! project_root#find()
     if !get(g:, 'JavaComplete_MavenRepositoryDisabled', 0)
-        if !exists('g:JavaComplete_PomPath')
-            if filereadable(getcwd() . g:utils#FILE_SEP . "pom.xml")
-                let g:JavaComplete_PomPath = getcwd() . g:utils#FILE_SEP . "pom.xml"
-            else
-                let g:JavaComplete_PomPath = project_root#find_file('pom.xml')
-            endif
-        endif
-        if g:JavaComplete_PomPath != ""
-            let g:JavaComplete_PomPath = fnamemodify(g:JavaComplete_PomPath, ':p')
-            return g:JavaComplete_PomPath
-        else
-            unlet g:JavaComplete_PomPath
+        let rootfile = s:find_root_pattern('pom.xml')
+        if rootfile != ""
+           let g:JavaComplete_PomPath = rootfile
+           return rootfile
         endif
     endif
 
     if !get(g:, 'JavaComplete_GradleRepositoryDisabled', 0)
-        if !exists('g:JavaComplete_GradlePath')
-            if filereadable(getcwd() . g:utils#FILE_SEP . "build.gradle")
-                let g:JavaComplete_GradlePath = getcwd() . g:utils#FILE_SEP . "build.gradle"
-            else
-                let g:JavaComplete_GradlePath = project_root#find_file('build.gradle')
-            endif
-        endif
-        if g:JavaComplete_GradlePath != ""
-            let g:JavaComplete_GradlePath = fnamemodify(g:JavaComplete_GradlePath, ':p')
-            return g:JavaComplete_GradlePath
-        else
-            unlet g:JavaComplete_GradlePath
+        let rootfile = s:find_root_pattern("build.gradle")
+        if rootfile != ""
+          let g:JavaComplete_GradlePath = rootfile
+          return rootfile
         endif
     endif
 
     if !get(g:, 'JavaComplete_AntRepositoryDisabled', 0)
-        if !exists('g:JavaComplete_AntPath')
-            if filereadable(getcwd() . g:utils#FILE_SEP . "build.xml")
-                let g:JavaComplete_AntPath = getcwd() . g:utils#FILE_SEP . "build.xml"
-            else
-                let g:JavaComplete_AntPath = project_root#find_file('build.xml')
-            endif
-        endif
-        if g:JavaComplete_AntPath != ""
-            let g:JavaComplete_AntPath = fnamemodify(g:JavaComplete_AntPath, ':p')
-            return g:JavaComplete_AntPath
-        else
-            unlet g:JavaComplete_AntPath
+        let rootfile = s:find_root_pattern('build.xml')
+        if rootfile != ""
+          let g:JavaComplete_AntPath = rootfile
+          return rootfile
         endif
     endif
+
+    for p in g:project_root#patterns
+      let rootfile = s:find_root_pattern(p)
+      if rootfile != ''
+        return rootfile
+      endif
+    endfor
 
     return getcwd()
 endfunction

--- a/autoload/utils.vim
+++ b/autoload/utils.vim
@@ -1,3 +1,13 @@
+if has('macunix')
+  let utils#OS = 'mac'
+elseif has('win32')
+  let utils#OS = 'win'
+else
+  let utils#OS = system('uname')->substitute('\n', '', '')->tolower()
+endif
+
+let utils#FILE_SEP = fnamemodify(getcwd(), ':p')->substitute('.*\(.\)$', '\1', '')
+
 function! utils#trim(str)
   let str = substitute(a:str, '^\s*', '', '')
   return substitute(str, '\s*$', '', '')

--- a/lua/jc/server.lua
+++ b/lua/jc/server.lua
@@ -158,6 +158,7 @@ local function lspconfig_setup(paths)
   -- stylua: ignore
   local cmd = {
     M.config.java_exec,
+    --'-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4004',
     "-javaagent:" .. paths.jdtls.lombok,
     "-Declipse.application=org.eclipse.jdt.ls.core.id1",
     "-Dosgi.bundles.defaultStartLevel=4",

--- a/lua/jc/vimspector.lua
+++ b/lua/jc/vimspector.lua
@@ -16,26 +16,26 @@ end
 local function resolve_main_class(callback)
   lsp.executeCommand({ command = "vscode.java.resolveMainClass" }, function(response)
     if #response > 0 then
-      callback(response[1].mainClass)
+      callback(response[1].mainClass, response[1].projectName)
     else
       callback()
     end
   end)
 end
 
-local function resolve_classpaths(main_class, callback)
+local function resolve_classpaths(main_class, project_name, callback)
   lsp.executeCommand({
     command = "vscode.java.resolveClasspath",
     arguments = {
       main_class,
-      vim.fn["project_root#get_project_name"](),
+      project_name,
     },
   }, callback, callback)
 end
 
 function M.debug_launch()
-  resolve_main_class(function(main_class)
-    resolve_classpaths(main_class, function(classpaths)
+  resolve_main_class(function(main_class, project_name)
+    resolve_classpaths(main_class, project_name, function(classpaths)
       if not classpaths then
         classpaths = { "${workspaceRoot}/" }
       else

--- a/plugin/jc.vim
+++ b/plugin/jc.vim
@@ -1,7 +1,8 @@
 if exists('g:loaded_jc_nvim') | finish | endif
+
 let g:loaded_jc_nvim = v:true
 
-let g:JavaComplete_Home = fnamemodify(expand('<sfile>'), ':p:h:h:gs?\\?'. g:FILE_SEP. '?')
+let g:JavaComplete_Home = fnamemodify(expand('<sfile>'), ':p:h:h:gs?\\?'. g:utils#FILE_SEP. '?')
 
 autocmd FileType java autocmd BufWrite <buffer> lua vim.lsp.buf.format({ async = false })
 


### PR DESCRIPTION
* Enhance project_root detecting. And auto cd to project_root, if not, when we invoke nvim from $HOME, i.e. cd $HOME && nvim dev/myproject/src/main/..../Test.java, jdtls will start all gradle instances in .gradle/wrapper/, it could be tens of java instances, that is definitely unexpected.
* Move g:FILE_SEP to utils.vim as g:utils#FILE_SEP then we can load jc.nvim only with java files. I have tried to load jc with **autocmd FileType java**, jc.vim complains that g:FILE_SEP was not defined as it is initialized in project_root.vim, define it as util#FILE_SEP could solve it.
* Make jdtls config.settings configurable. I need to add more JavaSE versions to jdtls. I can do it now in init.vim:
```
lua << EOF
require'jc'.setup{
    settings = {
      java = {
        configuration = {
          runtimes = {
            {
              name = 'JavaSE-11',
              path = '/Library/Java/JavaVirtualMachines/java11/Contents/Home/'
            },
            {
              name = 'JavaSE-17',
              path = '/Library/Java/JavaVirtualMachines/java17/Contents/Home/'
            },
            {
              name = 'JavaSE-1.8',
              path = '/Library/Java/JavaVirtualMachines/java8/Contents/Home/',
              default = true
            }
          }
     }
  }
}
EOF
```
* Another small fix, config_linux is hard-coded in lua script. Now I introduce a new variable **utils#OS** in utils.vim.