### PR TITLE
To enable jumping to classes from vimspector stack window

### DIFF
--- a/lua/jc.lua
+++ b/lua/jc.lua
@@ -25,17 +25,4 @@ function M.run_setup()
   server.jdtls_setup(M.config)
 end
 
-local definitions_handler = vim.lsp.handlers["textDocument/definition"]
-
-local function custom_def_handler(_, result, ctx, conf)
-  if vim.startswith(result[1].uri, "jdt:/") then
-    jdtls.read_class_content({ result = result, ctx = ctx, config = conf }, definitions_handler)
-  else
-    definitions_handler(nil, result, ctx, conf)
-  end
-end
-vim.lsp.handlers["textDocument/definition"] = custom_def_handler
-vim.lsp.handlers["textDocument/declaration"] = custom_def_handler
-vim.lsp.handlers["textDocument/implementation"] = custom_def_handler
-
 return M

--- a/lua/jc/lsp.lua
+++ b/lua/jc/lsp.lua
@@ -41,7 +41,7 @@ function M.executeCommand(command, callback, on_failure)
 end
 
 function M.get_jdtls_client()
-  local clients = vim.lsp.buf_get_clients()
+  local clients = vim.lsp.get_active_clients()
   for _, client in ipairs(clients) do
     if client.name == "jdtls" then
       return client

--- a/plugin/jc.vim
+++ b/plugin/jc.vim
@@ -5,6 +5,7 @@ let g:loaded_jc_nvim = v:true
 let g:JavaComplete_Home = fnamemodify(expand('<sfile>'), ':p:h:h:gs?\\?'. g:utils#FILE_SEP. '?')
 
 autocmd FileType java call jc#Autoload()
+au BufReadCmd,FileReadCmd,SourceCmd jdt://* lua require('jc.jdtls').read_class_content(vim.fn.expand("<amatch>"))
 
 command! JCdebugAttach lua require('jc.vimspector').debug_attach()
 command! JCdebugLaunch lua require('jc.vimspector').debug_launch()


### PR DESCRIPTION
 Change another way to open jdt://* url, so that we can open class from vimspector stack window.